### PR TITLE
Dynamic connection types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 [![npm version](https://badge.fury.io/js/mintbean-cli.svg)](https://badge.fury.io/js/mintbean-cli)
 ### status: Not quite ready :)
-CLI currently templates `vanilla-js` and `react-gh-pages`, with bug that image files don't copy over. In new projects still need to manually run
+CLI currently templates `vanilla-js` and `react-gh-pages`. Only react is deployable by `mint` command at this time: After creating new project (`mint n <my-app>` > `react-gh-pages`) you still need to manually do the following to deploy
 ```
-git init
-/* create remote repo */
-/* react */
+mint r -c      ** creates and connects to remote repo ** 
 yarn install
 yarn deploy
 ```

--- a/commands/config.js
+++ b/commands/config.js
@@ -1,0 +1,24 @@
+const chalk = require('chalk');
+const getConfig = require('../lib/config.js').getConfig;
+const setConfig = require('../lib/config.js').setConfig;
+
+const parse = (cmdObj) => {
+  if (cmdObj.view) {
+    console.log(chalk.cyanBright('Your config:'));
+    console.log(`(-g) github username: ${getConfig('github')}`);
+    console.log(`(-t) token: ${getConfig('token') ? '<hidden>' : 'undefined'}`);
+    return
+  }
+  if (cmdObj.github) {
+    setConfig('github', cmdObj.github)
+    console.log(chalk.cyanBright(`Successfully set github username to '${cmdObj.github}'`));
+  }
+  if (cmdObj.token) {
+    setConfig('token', cmdObj.token)
+    console.log(chalk.cyanBright(`Successfully set github personal access token.`));
+  }
+}
+
+module.exports = {
+  parse,
+}

--- a/commands/config.js
+++ b/commands/config.js
@@ -2,23 +2,41 @@ const chalk = require('chalk');
 const getConfig = require('../lib/config.js').getConfig;
 const setConfig = require('../lib/config.js').setConfig;
 
-const parse = (cmdObj) => {
-  if (cmdObj.view) {
-    console.log(chalk.cyanBright('Your config:'));
-    console.log(`(-g) github username: ${getConfig('github')}`);
-    console.log(`(-t) token: ${getConfig('token') ? '<hidden>' : 'undefined'}`);
-    return
+const config = (cmdObj) => {
+  // return if choosing multiple connection types simulataneously
+  if(cmdObj.ssh && cmdObj.https) {
+    console.log(chalk.red('Nooo! Choose only one connection type: ssh (-S) OR https (-H). Try again.'));
+    return false
   }
+  if (cmdObj.view || cmdObj.parent.args.length === 1) {
+    console.log(chalk.cyanBright('Your current config:'));
+    console.log(`github username:  ${getConfig('github')}`);
+    console.log(`token:            ${getConfig('token') ? '<hidden>' : 'undefined'}`);
+    console.log(`connection type:  ${getConfig('connection') ? getConfig('connection') : 'undefined'}`);
+    console.log(chalk.cyanBright("Run 'mint config -h' to learn how to update preferences"));
+    return true
+  }
+
   if (cmdObj.github) {
     setConfig('github', cmdObj.github)
     console.log(chalk.cyanBright(`Successfully set github username to '${cmdObj.github}'`));
   }
+
   if (cmdObj.token) {
     setConfig('token', cmdObj.token)
     console.log(chalk.cyanBright(`Successfully set github personal access token.`));
   }
+
+  if (cmdObj.ssh) {
+    setConfig('connection', 'ssh')
+    console.log(chalk.cyanBright(`Successfully set github connection type to ssh.`));
+  }
+  if (cmdObj.https) {
+    setConfig('connection', 'https')
+    console.log(chalk.cyanBright(`Successfully set github connection type to https.`));
+  }
 }
 
 module.exports = {
-  parse,
+  config,
 }

--- a/commands/connect.js
+++ b/commands/connect.js
@@ -1,0 +1,22 @@
+const chalk = require('chalk');
+const files = require('../lib/files');
+const git = require('../lib/git');
+const getConfig = require('../lib/config').getConfig;
+
+const connect = (username, project, connection) => {
+  console.log(chalk.cyanBright('Connecting remote origin...'));
+  const githubUsername = username || getConfig('github');
+  const projectName = project || files.getCurrentDirectoryBase();
+  const connectionType = connection || getConfig('connection');
+
+  git.createOrOverrideRemoteOrigin(githubUsername, projectName, connectionType);
+
+  console.log(chalk.cyanBright("To make first push:"));
+  console.log("git add .");
+  console.log("git commit -m \"init\"");
+  console.log("git push origin master");
+}
+
+module.exports = {
+  connect, 
+}

--- a/commands/repo.js
+++ b/commands/repo.js
@@ -4,7 +4,7 @@ const files = require('../lib/files.js');
 const getConfig = require('../lib/config').getConfig;
 const git = require('../lib/git');
 const github = require('../lib/github');
-
+const connect = require('./connect').connect;
 
 const repo = (cmdObj) => {
   const githubUsername = getConfig('github');
@@ -19,12 +19,8 @@ const repo = (cmdObj) => {
   const success = github.createRepo(githubUsername, githubToken, projectName);
   if (!success) return
   if(cmdObj.connect) {
-    console.log(chalk.cyanBright('Connecting remote origin...'));
-    git.createOrOverrideRemoteOrigin(githubUsername, projectName);
-    console.log(chalk.cyanBright("To make first push:"));
-    console.log("git add .");
-    console.log("git commit -m \"init\"");
-    console.log("git push origin master");
+    const connectionType = getConfig('connection');
+    connect(githubUsername, projectName, connectionType);
   }
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,26 +11,26 @@ const getConfig = (key) => {
 const setConfig = (key, val) => {
   Pref.set(key, val)
 }
-
-const parse = (cmdObj) => {
-  if (cmdObj.view) {
-    console.log('Your config:')
-    console.log(`(-g) github username: ${Pref.get('github')}`)
-    console.log(`(-t) token: ${Pref.get('token') ? '<hidden>' : 'undefined'}`)
-    return
-  }
-  if (cmdObj.github) {
-    Pref.set('github', cmdObj.github)
-    console.log(`Successfully set github username to '${cmdObj.github}'`)
-  }
-  if (cmdObj.token) {
-    Pref.set('token', cmdObj.token)
-    console.log(`Successfully set github personal access token.`)
-  }
-}
+//
+// const parse = (cmdObj) => {
+//   if (cmdObj.view) {
+//     console.log('Your config:')
+//     console.log(`(-g) github username: ${Pref.get('github')}`)
+//     console.log(`(-t) token: ${Pref.get('token') ? '<hidden>' : 'undefined'}`)
+//     return
+//   }
+//   if (cmdObj.github) {
+//     Pref.set('github', cmdObj.github)
+//     console.log(`Successfully set github username to '${cmdObj.github}'`)
+//   }
+//   if (cmdObj.token) {
+//     Pref.set('token', cmdObj.token)
+//     console.log(`Successfully set github personal access token.`)
+//   }
+// }
 
 module.exports = {
-  parse,
+  // parse,
   getConfig,
   setConfig
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,3 @@
-const chalk = require('chalk');
 const Pref = require('dotpref').Pref;
 
 // returns false if no key or value is undefined, returns value if key
@@ -11,26 +10,8 @@ const getConfig = (key) => {
 const setConfig = (key, val) => {
   Pref.set(key, val)
 }
-//
-// const parse = (cmdObj) => {
-//   if (cmdObj.view) {
-//     console.log('Your config:')
-//     console.log(`(-g) github username: ${Pref.get('github')}`)
-//     console.log(`(-t) token: ${Pref.get('token') ? '<hidden>' : 'undefined'}`)
-//     return
-//   }
-//   if (cmdObj.github) {
-//     Pref.set('github', cmdObj.github)
-//     console.log(`Successfully set github username to '${cmdObj.github}'`)
-//   }
-//   if (cmdObj.token) {
-//     Pref.set('token', cmdObj.token)
-//     console.log(`Successfully set github personal access token.`)
-//   }
-// }
 
 module.exports = {
-  // parse,
   getConfig,
   setConfig
 }

--- a/lib/git.js
+++ b/lib/git.js
@@ -7,6 +7,16 @@ const chalk = require('chalk');
 const generateRemoteLinkSsh = (username, projectName) => {
   return `git@github.com:${username}/${projectName}.git`
 }
+const generateRemoteLinkHttps = (username, projectName) => {
+  return `https://github.com/${username}/${projectName}.git`
+}
+const generateRemoteLink = (username, projectName, connectionType) => {
+  if (connectionType === 'https') {
+    return generateRemoteLinkHttps(username, projectName);
+  } else {
+    return generateRemoteLinkSsh(username, projectName);
+  }
+}
 
 // Native actions
 const init = () => {
@@ -22,7 +32,7 @@ const removeRemote = (name) => {
 }
 
 // Custom actions
-const createOrOverrideRemoteOrigin = (username, projectName) => {
+const createOrOverrideRemoteOrigin = (username, projectName, connectionType) => {
   // git init if needed
   if(!hasGitInitialized()) {
     console.log(chalk.cyanBright('Intializing git...'));
@@ -33,7 +43,7 @@ const createOrOverrideRemoteOrigin = (username, projectName) => {
     removeRemote('origin');
   }
   // create new remote origin connection
-  const remote = generateRemoteLinkSsh(username, projectName);
+  const remote = generateRemoteLink(username, projectName, connectionType);
   addRemote('origin', remote);
   console.log(chalk.cyanBright("Updated remote connection for 'origin':"));
   console.log(getRemotes())

--- a/lib/github.js
+++ b/lib/github.js
@@ -5,13 +5,17 @@ const git = require('./git');
 // VALIDATIONS
 const validateGithubCredentials = (username, token) => {
   if (!username || !token) {
-    let missing = []
-    if(!username) missing.push('github-username');
-    if(!token) missing.push('github-token');
-    console.log(chalk.red(`Missing config: ${missing.join(', ')}`))
-    console.log(chalk.red("Run 'mint config -g <github-username> -t <github-token>' to set up missing credentials"))
-    console.log("Add new GitHub personal access token called 'mintbean-cli' with 'repo' and 'user' permissions: ")
-    console.log("https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token")
+    if(!username) {
+      console.log(chalk.red("Missing GitHub username. Add it to config:"));
+      console.log("mint config -g <username>");
+    }
+    if (!token) {
+      console.log(chalk.red("Missing GitHub personal access token. Add it to config:"));
+      console.log("mint config -t <token>");
+      console.log(chalk.cyanBright("To get a GitHub personal access token, follow link below. Name your token 'mintbean-cli' and give it permissions 'repo' and 'user'. Copy this token and set it with 'mint config -t <token>': "));
+      console.log("https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token");
+      console.log(chalk.red("*Connection type defaults to 'ssh'. You can change this preference to 'https' by running 'mint config -H'"));
+    }
     return true
   }
   return false

--- a/program.js
+++ b/program.js
@@ -4,8 +4,9 @@ const fs = require('fs');
 const { Command } = require('commander');
 const shell = require('shelljs');
 
-const config = require('./commands/config');
+const config = require('./commands/config').config;
 const create = require('./commands/new');
+const connect = require('./commands/connect').connect;
 const init = require('./commands/init').initialize;
 const repo = require('./commands/repo').repo;
 const { version } = require("./package.json");
@@ -49,6 +50,15 @@ const createProgram = () => {
     });
 
   program
+    .command('connect')
+    .alias('c')
+    // .option('-c, --connect', "Set project's remote origin to new repo")
+    .description('Add or override remote origin with github preferences in config')
+    .action(function () {
+      connect()
+    });
+
+  program
     .command('config')
     .description('Set up or view config (Github credentials etc.)')
     .option('-v, --view', 'view current config')
@@ -57,7 +67,7 @@ const createProgram = () => {
     .option('-S, --ssh', 'set github connection type to ssh')
     .option('-H, --https', 'set github connection type to https')
     .action((cmdObj) => {
-      config.parse(cmdObj)
+      config(cmdObj)
     });
 
   return program;

--- a/program.js
+++ b/program.js
@@ -4,8 +4,7 @@ const fs = require('fs');
 const { Command } = require('commander');
 const shell = require('shelljs');
 
-const connect = require('./commands/connect').connect;
-const config = require('./lib/config');
+const config = require('./commands/config');
 const create = require('./commands/new');
 const init = require('./commands/init').initialize;
 const repo = require('./commands/repo').repo;
@@ -54,7 +53,9 @@ const createProgram = () => {
     .description('Set up or view config (Github credentials etc.)')
     .option('-v, --view', 'view current config')
     .option('-g, --github <username>', 'set github username')
-    .option('-t, --token <token', 'set github personal access token')
+    .option('-t, --token <token>', 'set github personal access token')
+    .option('-S, --ssh', 'set github connection type to ssh')
+    .option('-H, --https', 'set github connection type to https')
     .action((cmdObj) => {
       config.parse(cmdObj)
     });


### PR DESCRIPTION
now allows config of preferred github connection type: ssh or https (defaults to ssh)
`mint config -S|-ssh` or `mint config -H|--https`

added command `mint connect` for setting up default remote origin without creating new remote repo
