### PR TITLE
Remove mint dev from Readme and replace with npm/yarn start

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If it is your first time using `mintbean-cli`, first connect to GitHub with conf
 ```shell
 mint new <my-project>
 cd <my-project>
-mint repo 
+mint repo
 mint deploy
 ```
 
@@ -74,7 +74,7 @@ View your config settings anytime with `mint config -v`.
 
 ### Development
 
-`mint develop` or `mint dev`
+`npm start` or `yarn start`
 
 Starts a local development server to display your code's output (look for `localhost` link). Changes to your code automatically updates when you save.
 
@@ -98,7 +98,7 @@ Basic Create React App template.
 
 ### vanilla-js-gh-pages
 
-Basic vanilla JavaScript template that allows you to preview your project on a local server (`mint dev`)
+Basic vanilla JavaScript template that allows you to preview your project on a local server (`npm start` or `yarn start` to start the server)
 
 ### vue-gh-pages
 

--- a/templates/phaser/README.md
+++ b/templates/phaser/README.md
@@ -5,7 +5,7 @@
 1. Mint new [ Project name ]
 2. Select `phaser-gh-pages`
 3. `mint r -cp`
-4. `mint develop`
+4. `npm start` or `yarn start`
 5. Visit `localhost:1234`
 
 ## Deployment

--- a/templates/svelte/README.md
+++ b/templates/svelte/README.md
@@ -5,7 +5,7 @@
 1. Mint new [ Project name ]
 2. Select `svelte-gh-pages`
 3. `mint r -cp`
-4. `mint develop`
+4. `npm start` or `yarn start`
 5. Visit `localhost:5000`
 
 ## Deployment


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

This PR removes everything related to `mint dev` from the documentation, and replaces it with `npm start` and `yarn start`.

## Added to documentation?

- [X] readme
- [ ] no documentation needed
